### PR TITLE
Fix JD matches only supporting 5 char IDs

### DIFF
--- a/api/jd/matches/v130/index.php
+++ b/api/jd/matches/v130/index.php
@@ -21,7 +21,7 @@
 		$date = trim($date);
 		//check to see if there's a ':' in the string (denonating a finished game)
 		if (!strpos($date, ':')) {
-			$id = substr($id, -5);
+			$id = str_replace('score_','',$id);
 			$linkID = "http://www.joindota.com/en/matches/{$id}";
 			$titleExt = file_get_contents($linkID);
 			$titleList->load($titleExt);

--- a/api/jd/matches/v152/index.php
+++ b/api/jd/matches/v152/index.php
@@ -21,7 +21,7 @@
 		$date = trim($date);
 		//check to see if there's a ':' in the string (denonating a finished game)
 		if (!strpos($date, ':')) {
-			$id = substr($id, -5);
+			$id = str_replace('score_','',$id);
 			$linkID = "http://www.joindota.com/en/matches/{$id}";
 			$titleExt = file_get_contents($linkID);
 			$titleList->load($titleExt);

--- a/api/v2/jd/jd.php
+++ b/api/v2/jd/jd.php
@@ -23,7 +23,7 @@
     $date = trim($date);
     //check to see if there's a ':' in the string (denonating a finished game)
     if (!strpos($date, ':')) {
-      $id = substr($id, -5);
+      $id = str_replace('score_','',$id);
       $linkID = "http://www.joindota.com/en/matches/{$id}";
       $titleExt = file_get_contents($linkID);
       $titleList->load($titleExt);


### PR DESCRIPTION
not sure which is the currently used API (v130 I think?)

apply as necessary, but this will obviously allow for the JD link to work so long as they don't change the site HTML anytime soon (so it'll work if they ever hit 7 character IDs).
