### PR TITLE
Fix #24

### DIFF
--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -82,7 +82,7 @@ tbody {
 }
 /*OVERWRITTING*/
 .nav {
-	margin-bottom:-1px !important;
+	margin-bottom: 0px !important;
 }
 .accordion {
 	margin-bottom: 0px !important;


### PR DESCRIPTION
Fixes #24.

With a negative margin-bottom, the tab content aligns to the right of nav-tabs (in Chrome 54.0).
Changing it to a non-negative number fixes the issue.